### PR TITLE
Updated to run on OCP OTTB

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,16 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  linting:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: phplint
+        uses: overtrue/phplint@master
+        with:
+          path: .
+          options: --exclude=*.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+/.project
+.DS_Store
+.idea
+*.swp
+__pycache__
+.odo
+.vscode

--- a/.openshift/1-mysql.yaml
+++ b/.openshift/1-mysql.yaml
@@ -1,0 +1,133 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    annotations:
+      template.openshift.io/expose-database_name: '{.data[''database-name'']}'
+      template.openshift.io/expose-password: '{.data[''database-password'']}'
+      template.openshift.io/expose-root_password: '{.data[''database-root-password'']}'
+      template.openshift.io/expose-username: '{.data[''database-user'']}'
+    labels:
+      template: mysql-persistent-template
+    name: mysql
+  stringData:
+    database-name: spider
+    database-password: p57gVU2YKymU8N7N
+    database-root-password: 3btTdLWNL7QOygCK
+    database-user: rti
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      template.openshift.io/expose-uri: mysql://{.spec.clusterIP}:{.spec.ports[?(.name=="mysql")].port}
+    labels:
+      template: mysql-persistent-template
+    name: mysql
+  spec:
+    ports:
+    - name: mysql
+      port: 3306
+    selector:
+      name: mysql
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    labels:
+      template: mysql-persistent-template
+    name: mysql
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+- apiVersion: apps.openshift.io/v1
+  kind: DeploymentConfig
+  metadata:
+    annotations:
+      template.alpha.openshift.io/wait-for-ready: "true"
+    labels:
+      template: mysql-persistent-template
+    name: mysql
+  spec:
+    replicas: 1
+    selector:
+      name: mysql
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          name: mysql
+      spec:
+        containers:
+        - env:
+          - name: MYSQL_DEFAULT_AUTHENTICATION_PLUGIN
+            value: mysql_native_password
+          - name: MYSQL_USER
+            valueFrom:
+              secretKeyRef:
+                key: database-user
+                name: mysql
+          - name: MYSQL_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: database-password
+                name: mysql
+          - name: MYSQL_ROOT_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: database-root-password
+                name: mysql
+          - name: MYSQL_DATABASE
+            valueFrom:
+              secretKeyRef:
+                key: database-name
+                name: mysql
+          image: ' '
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -i
+              - -c
+              - MYSQL_PWD="$MYSQL_PASSWORD" mysqladmin -u $MYSQL_USER ping
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
+          name: mysql
+          ports:
+          - containerPort: 3306
+          readinessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -i
+              - -c
+              - MYSQL_PWD="$MYSQL_PASSWORD" mysqladmin -u $MYSQL_USER ping
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              memory: 512Mi
+          volumeMounts:
+          - mountPath: /var/lib/mysql/data
+            name: mysql-data
+        volumes:
+        - name: mysql-data
+          persistentVolumeClaim:
+            claimName: mysql
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - mysql
+        from:
+          kind: ImageStreamTag
+          name: mysql:8.0-el8
+          namespace: openshift
+      type: ImageChange
+    - type: ConfigChange
+kind: List
+metadata: {}

--- a/.openshift/2-db-init.yaml
+++ b/.openshift/2-db-init.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+items:
+- apiVersion: batch/v1
+  kind: Job
+  metadata:
+    name: rti-db-init
+  spec:
+    backoffLimit: 0
+    template:
+      spec:
+        containers:
+          - name: mysql
+            image: image-registry.openshift-image-registry.svc:5000/openshift/mysql:8.0-el8
+            command: [ "/bin/sh","-c" ]
+            args: [ "curl https://raw.githubusercontent.com/redhat-cop/rti/master/database.sql | mysql --host=${MYSQL_SVC} --database=${MYSQL_DATABASE} --user=${MYSQL_USER} --password=${MYSQL_PASSWORD}" ]
+            env:
+              - name: MYSQL_SVC
+                value: mysql
+              - name: MYSQL_USER
+                valueFrom:
+                  secretKeyRef:
+                    key: database-user
+                    name: mysql
+              - name: MYSQL_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    key: database-password
+                    name: mysql
+              - name: MYSQL_DATABASE
+                valueFrom:
+                  secretKeyRef:
+                    key: database-name
+                    name: mysql
+        restartPolicy: Never
+kind: List
+metadata: {}

--- a/.openshift/3-app.yml
+++ b/.openshift/3-app.yml
@@ -1,0 +1,171 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: captcha
+  stringData:
+    sitekey: replace_me
+    secretkey: replace_me
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/generated-by: OpenShiftNewApp
+    creationTimestamp: null
+    labels:
+      app: rti
+      app.kubernetes.io/component: rti
+      app.kubernetes.io/instance: rti
+    name: rti
+  spec:
+    lookupPolicy:
+      local: false
+  status:
+    dockerImageRepository: ""
+- apiVersion: build.openshift.io/v1
+  kind: BuildConfig
+  metadata:
+    annotations:
+      openshift.io/generated-by: OpenShiftNewApp
+    creationTimestamp: null
+    labels:
+      app: rti
+      app.kubernetes.io/component: rti
+      app.kubernetes.io/instance: rti
+    name: rti
+  spec:
+    nodeSelector: null
+    output:
+      to:
+        kind: ImageStreamTag
+        name: rti:latest
+    postCommit: {}
+    resources: {}
+    source:
+      git:
+        uri: https://github.com/redhat-cop/rti.git
+      type: Git
+    strategy:
+      sourceStrategy:
+        from:
+          kind: ImageStreamTag
+          name: php:7.3-ubi8
+          namespace: openshift
+      type: Source
+    triggers:
+    - type: ConfigChange
+    - imageChange: {}
+      type: ImageChange
+  status:
+    lastVersion: 0
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    annotations:
+      image.openshift.io/triggers: '[{"from":{"kind":"ImageStreamTag","name":"rti:latest"},"fieldPath":"spec.template.spec.containers[?(@.name==\"rti\")].image"}]'
+      openshift.io/generated-by: OpenShiftNewApp
+    creationTimestamp: null
+    labels:
+      app: rti
+      app.kubernetes.io/component: rti
+      app.kubernetes.io/instance: rti
+    name: rti
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        deployment: rti
+    strategy: {}
+    template:
+      metadata:
+        annotations:
+          openshift.io/generated-by: OpenShiftNewApp
+        creationTimestamp: null
+        labels:
+          deployment: rti
+      spec:
+        containers:
+        - image: ' '
+          name: rti
+          env:
+            - name: MYSQL_SVC
+              value: mysql
+            - name: MYSQL_USER
+              valueFrom:
+                secretKeyRef:
+                  key: database-user
+                  name: mysql
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: database-password
+                  name: mysql
+            - name: MYSQL_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  key: database-name
+                  name: mysql
+            - name: CAPTCHA_SITEKEY
+              valueFrom:
+                secretKeyRef:
+                  key: sitekey
+                  name: captcha
+            - name: CAPTCHA_SECRETKEY
+              valueFrom:
+                secretKeyRef:
+                  key: secretkey
+                  name: captcha
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          - containerPort: 8443
+            protocol: TCP
+          resources: {}
+  status: {}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      openshift.io/generated-by: OpenShiftNewApp
+    creationTimestamp: null
+    labels:
+      app: rti
+      app.kubernetes.io/component: rti
+      app.kubernetes.io/instance: rti
+    name: rti
+  spec:
+    ports:
+    - name: 8080-tcp
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    - name: 8443-tcp
+      port: 8443
+      protocol: TCP
+      targetPort: 8443
+    selector:
+      deployment: rti
+  status:
+    loadBalancer: {}
+- kind: Route
+  apiVersion: route.openshift.io/v1
+  metadata:
+    name: rti
+    labels:
+      app: rti
+      app.kubernetes.io/component: rti
+      app.kubernetes.io/instance: rti
+  spec:
+    to:
+      kind: Service
+      name: rti
+      weight: 100
+    port:
+      targetPort: 8080-tcp
+    tls:
+      termination: edge
+      insecureEdgeTerminationPolicy: Redirect
+    wildcardPolicy: None
+kind: List
+metadata: {}

--- a/README.md
+++ b/README.md
@@ -1,23 +1,54 @@
 # Ready To Innovate
+Ready to Innovate tests organization's readiness to adopt emerging technologies. 
+Ready to Innovate shows that a holistic strategy can allow organizations to make the changes they need to meet new demands in the IT industry.
 
-## Requirements
-*  PHP
-*  MySQL
+## Running Locally
+### Requirements
+* PHP
+* MySQL
 * Apache
 
-## Setup
-Use database.sql to setup the table for the spider database.
+### Setup Database
+The `dbconnect.php` uses the following environment variables to resolve your mysql credentials.
 
-Edit dbconnect.php with your mysql credentials.
+```bash
+export MYSQL_SVC=localhost
+export MYSQL_USER=replace_me
+export MYSQL_PASSWORD=replace_me
+export MYSQL_DATABASE=spider
+```
 
-Create the database and tables:
+Once the above envs are set, we can create the tables required:
 
-mysql -u XXXX -p readytoi_spider < database.sql
+```
+curl https://raw.githubusercontent.com/redhat-cop/rti/master/database.sql | mysql --host=${MYSQL_SVC} --database=${MYSQL_DATABASE} --user=${MYSQL_USER} --password=${MYSQL_PASSWORD}
+```
 
-This app uses a captcha to ensure no robot creation of users.
+## Setup captcha
+This app uses a captcha in `register.php` to ensure no robot creation of users.
+To register with recaptcha v2, visit: https://www.google.com/recaptcha/intro
+
+```bash
+export CAPTCHA_SITEKEY=replace_me
+export CAPTCHA_SECRETKEY=replace_me
+````
 
 Securimage: A PHP class dealing with CAPTCHA images, audio, and validation
 https://www.phpcaptcha.org/documentation/quickstart-guide/
 
-To register with recaptcha, visit: https://www.google.com/recaptcha/intro/v3.html
+## Deploying on OpenShift
+NOTE: The `.openshift/3-app.yml` `Secret/captcha` needs updating before deploying.
 
+```bash
+oc new-project rti
+
+oc create -f .openshift/1-mysql.yaml
+oc rollout status dc/mysql --watch=true
+
+oc create -f .openshift/2-db-init.yaml
+
+oc create -f .openshift/3-app.yml
+oc rollout status deployment/rti --watch=true
+
+open "https://$(oc get route rti -o jsonpath={.spec.host})"
+```

--- a/database.sql
+++ b/database.sql
@@ -52,9 +52,9 @@ CREATE TABLE `data` (
   `comments_wayOfWorking` text DEFAULT NULL,
   `comments_architecture` text DEFAULT NULL,
   `comments_environment` text DEFAULT NULL,
-  `comments_visionLeadership` text DEFAULT NULL
+  `comments_visionLeadership` text DEFAULT NULL,
+  `demo` text DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
 -- --------------------------------------------------------
 
 --

--- a/dbconnect.php
+++ b/dbconnect.php
@@ -1,14 +1,19 @@
 <?php
 function connectDB() {
 ## Database stuff
+$db_svc = getenv('MYSQL_SVC', true) ?: "localhost";
+$db_user = getenv('MYSQL_USER', true) ?: "XXXXX";
+$db_pass = getenv('MYSQL_PASSWORD', true) ?: "XXXXX";
+$db_name = getenv('MYSQL_DATABASE', true) ?: "spider";
+
 global $db;
-$db = ($GLOBALS["___mysqli_ston"] = mysqli_connect('localhost', 'XXXXX', 'XXXX'));
+$db = ($GLOBALS["___mysqli_ston"] = mysqli_connect($db_svc, $db_user, $db_pass));
 
 	if (!$db) {
 	die("Unable to connect to database");
 	}
 ##if (!mysql_select_db('spider')) {
-if (!mysqli_select_db($GLOBALS["___mysqli_ston"], "spider")) 
+if (!mysqli_select_db($GLOBALS["___mysqli_ston"], $db_name))
 {		
 	die("Unable to access spider database");
 	}

--- a/register.php
+++ b/register.php
@@ -22,6 +22,9 @@ connectDB();
 //set validation error flag as false
 $error = false;
 
+$captcha_sitekey = getenv('CAPTCHA_SITEKEY', true) ?: "REPLACE_ME";
+$captcha_secretkey = getenv('CAPTCHA_SECRETKEY', true) ?: "REPLACE_ME";
+
 //check if form is submitted
 if (isset($_POST['signup'])) {
 	$name = mysqli_real_escape_string($GLOBALS["___mysqli_ston"], $_POST['name']);
@@ -64,7 +67,7 @@ curl_setopt_array($curl, array(
     CURLOPT_URL => 'https://www.google.com/recaptcha/api/siteverify',
     CURLOPT_POST => 1,
     CURLOPT_POSTFIELDS => array(
-        'secret' => 'XXXXXXXXXXXXXXXXXXXXXXX',
+        'secret' => $captcha_secretkey,
         'response' => $_POST['g-recaptcha-response']
     )
 ));
@@ -86,7 +89,9 @@ if(strpos($resp, '"success": true') !== FALSE) {
 			$errormsg = "Error in registering...Please try again later!";
 		}
 
-} 
+} else {
+    $errormsg = "Error in siteverify for recaptcha...Please contact the site admin!";
+}
 
 }
 ?>
@@ -160,7 +165,7 @@ if(strpos($resp, '"success": true') !== FALSE) {
         <?php #echo Securimage::getCaptchaHtml() ?>
         						<span class="text-danger"><?php if (isset($captcha_error)) echo "<br>$captcha_error"; ?></span>
     </div>
-<div class="g-recaptcha" data-sitekey="XXXXXXXXXXXXXXXXXXXXXXXX"></div>
+<div class="g-recaptcha" data-sitekey="<?php echo $captcha_sitekey; ?>"></div>
 					<div class="form-group">
 						<input type="submit" name="signup" value="Sign Up" class="btn btn-primary" />
 					</div>


### PR DESCRIPTION
This PR adds:
- github action to lint the PHP - i.e.: does a PR miss a `;`
- added OCP templates and externalises a few configs to envs
- fixes: https://github.com/redhat-cop/rti/issues/12

This PR is currently deployed below, if you want to check everything is working correctly:
- https://rti-rti.apps.shared-na46.openshift.opentlc.com/