### PR TITLE
Bumping php image to 7.4-ubi8

### DIFF
--- a/.openshift/3-app.yml
+++ b/.openshift/3-app.yml
@@ -50,7 +50,7 @@ items:
       sourceStrategy:
         from:
           kind: ImageStreamTag
-          name: php:7.3-ubi8
+          name: php:7.4-ubi8
           namespace: openshift
       type: Source
     triggers:


### PR DESCRIPTION
php:7.3-ubi8 is not available

php7.3 seems to be available in the following imagestreams:
openshift/php:7.3-ubi7 pointing to registry.redhat.io/ubi7/php-73
openshift/php:7.3 pointing to registry.redhat.io/rhscl/php-73-rhel7