### PR TITLE
Removing extra demo column definition

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -53,8 +53,7 @@ CREATE TABLE `data` (
   `comments_wayOfWorking` text DEFAULT NULL,
   `comments_architecture` text DEFAULT NULL,
   `comments_environment` text DEFAULT NULL,
-  `comments_visionLeadership` text DEFAULT NULL,
-  `demo` text DEFAULT NULL
+  `comments_visionLeadership` text DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 -- --------------------------------------------------------
 


### PR DESCRIPTION
As the demo column is defined twice, the database initialisation will fail.

Removing the extra definition fixes the problem and allows initialisation to proceed.